### PR TITLE
PWDEXP - Correction to English language file

### DIFF
--- a/pwdexp/lang/en/auth_pwdexp.php
+++ b/pwdexp/lang/en/auth_pwdexp.php
@@ -1,8 +1,8 @@
 <?php
 $string['auth_pwdexptitle'] = 'Password Expiration Check';
-$string['auth_pwdexpdescription'] = "This authenticator checks if the password of the user needs to exipire.<br/>If so it will set the flag to force the account to change it's password and redirect to the given URL.<br/><br/>Be sure to save these settings at least once and after each change.";
+$string['auth_pwdexpdescription'] = "This authenticator checks if the user's password needs to expire.<br/>If so, it will set the flag to force the account to change its password and redirect to the given URL.<br/><br/>Be sure to save these settings at least once and after each change.";
 $string['auth_server_settings'] = "Password expiration check settings";
-$string['auth_expirationdays_key'] = "Expirationdays";
+$string['auth_expirationdays_key'] = "Days until expiry";
 $string['auth_expirationdays'] = "Number of days after which the password needs to expire.";
 $string['auth_redirecturl_key'] = "Redirect URL";
 $string['auth_redirecturl'] = "URL to redirect to when password has expired.";


### PR DESCRIPTION
Here are a couple of strings from the en/auth_pwdexp.php file that need to be updated.

CHANGE #1

The first change improves the clarity of the text and corrects a typo in the word expire (not exipire).

Is currently:

```
$string['auth_pwdexpdescription'] = "This authenticator checks if the password of the user needs to exipire.<br/>If so it will set the flag to force the account to change it's password and redirect to the given URL.<br/><br/>Be sure to save these settings at least once and after each change.";
```

Should be:

```
$string['auth_pwdexpdescription'] = "This authenticator checks if the user's password needs to expire.<br/>If so, it will set the flag to force the account to change its password and redirect to the given URL.<br/><br/>Be sure to save these settings at least once and after each change.";
```

CHANGE #2

This change is a re-write of a string that was missing a space between words and wasn't clear.

Is currently:

```
 $string['auth_expirationdays_key'] = "Expirationdays";
```

Should be:

```
 $string['auth_expirationdays_key'] = "Days until expiry";
```

I would appreciate it very much if you could integrate these 2 changes into future releases of the auth_pwdexp plugin.

Feel free to contact me if you have any questions or concerns.

Best regards,

Signed-off-by: Michael Milette michael.milette@instruxmedia.com
